### PR TITLE
Add display:flex to the sticky__content

### DIFF
--- a/index.scss
+++ b/index.scss
@@ -6,4 +6,5 @@
 
 .sticky__content{
   flex: 1 0 auto;
+  display: flex;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nib-styles/sticky-footer",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "Simple flexbox sticky footer by adding two classes",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This means the `align-items` defaults to `stretch` and the immediate child element(s) will fill the height of the content.

Useful for when this child has a background color that we want to fill the screen.