### PR TITLE
DA-775 - Fix IE

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Simple `flexbox` sticky footer by adding three classes
 
 Add `grow-layout` class to the direct parent element wrapping both the div you wish to expand and the footer.
 
-Unfortunately due to this issue in IE, we need a second wrapping element for this to work.
+Unfortunately due to this [flexbox issue in IE](https://github.com/philipwalton/flexbugs/blob/master/README.md#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items), we need a second wrapping element for this to work.
 
 Wrap your page with two divs with classes of `grow-layout` and `grow-layout__wrapper`. It is important that these divs are direct parents of the div you wish to expand and the header and footer elements.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @nib-styles/grow-layout
 
-Simple `flexbox` sticky footer by adding two classes
+Simple `flexbox` sticky footer by adding three classes
 
 ## Installation
 
@@ -10,10 +10,16 @@ Simple `flexbox` sticky footer by adding two classes
 
 Add `grow-layout` class to the direct parent element wrapping both the div you wish to expand and the footer.
 
+Unfortunately due to this issue in IE, we need a second wrapping element for this to work.
+
+Wrap your page with two divs with classes of `grow-layout` and `grow-layout__wrapper`. It is important that these divs are direct parents of the div you wish to expand and the header and footer elements.
+
 Add `grow-layout__content` class to the element you wish to expand to take up the remaining space on the page and push the footer to the bottom.
 
-    <div class="grow-layout"">
-        <header></header>
-        <div class="grow-layout__content"></div>
-        <footer></footer>
+    <div class="grow-layout">
+        <div class="grow-layout__wrapper">
+            <header></header>
+            <div class="grow-layout__content"> This div will grow vertically to fill the screen</div>
+            <footer></footer>
+        </div>
      </div>

--- a/index.scss
+++ b/index.scss
@@ -1,6 +1,11 @@
 .grow-layout {
   display: flex;
   flex-direction: column;
+}
+
+.grow-layout__wrapper {
+  display: flex;
+  flex-direction: column;
   min-height: 100vh;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nib-styles/grow-layout",
   "version": "2.0.0",
-  "description": "Simple flexbox layout to push footer to bottom by adding two classes",
+  "description": "Simple flexbox layout to push footer to bottom by adding three classes",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nib-styles/grow-layout.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nib-styles/grow-layout",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Simple flexbox layout to push footer to bottom by adding two classes",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We were having this issue: https://github.com/philipwalton/flexbugs/blob/master/README.md#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items

Wrapping the `.grow-layout` in another div fixes this.